### PR TITLE
I fixed the problems i told you earlier today. 

### DIFF
--- a/discord/application_commands.py
+++ b/discord/application_commands.py
@@ -145,7 +145,7 @@ class Localizations:
         try:
             return self.__languages_dict__.__getitem__(locale.value)
         except (KeyError, AttributeError):
-            if (locale.value not in self.__slots__  if isinstance(locale, Locale) else locale in self.__slots__):
+            if (locale.value not in self.__slots__  if isinstance(locale, Locale) else locale not in self.__slots__):
                 raise KeyError(f'Unknown locale "{locale}". See {api_docs}reference#locales for a list of locales.')
             raise KeyError(f'There is no locale value set for {locale.name}.')
 

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -3,7 +3,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) 2015-present Rapptz
+Copyright (c) 2015-2021 Rapptz & (c) 2021-present mccoderpy
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -406,7 +406,7 @@ class TextChannel(abc.Messageable, abc.GuildChannel, Hashable):
         count = 0
 
         minimum_time = int((time.time() - 14 * 24 * 60 * 60) * 1000.0 - 1420070400000) << 22
-        strategy = self.delete_messages if self._state.is_bot and bulk else _single_delete_strategy
+        strategy = self.delete_messages if bulk else _single_delete_strategy
 
         while True:
             try:

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -347,7 +347,6 @@ class ButtonColor(ButtonStyle):
     .. note ::
         This is just an Aliase to :class:`ButtonStyle`.
     """
-    pass
 
 
 class TextInputStyle(Enum):
@@ -573,6 +572,7 @@ class MessageType(Enum):
     application_command                          = 20
     thread_starter_message                       = 21
     guild_invite_reminder                        = 22
+
 
 
 class VoiceRegion(Enum):

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -380,9 +380,6 @@ class DiscordWebSocket:
             }
         }
 
-        if not self._connection.is_bot:
-            payload['d']['synced_guilds'] = []
-
         if self.shard_id is not None and self.shard_count is not None:
             payload['d']['shard'] = [self.shard_id, self.shard_count]
 

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -2199,29 +2199,6 @@ class Guild(Hashable):
         payload['max_age'] = 0
         return Invite(state=self._state, data=payload)
 
-    @utils.deprecated()
-    def ack(self):
-        """|coro|
-
-        Marks every message in this guild as read.
-
-        The user must not be a bot user.
-
-        .. deprecated:: 1.7
-
-        Raises
-        -------
-        HTTPException
-            Acking failed.
-        ClientException
-            You must not be a bot user.
-        """
-
-        state = self._state
-        if state.is_bot:
-            raise ClientException('Must not be a bot account to ack messages.')
-        return state.http.ack_guild(self.id)
-
     def audit_logs(self, *, limit=100, before=None, after=None, oldest_first=None, user=None, action=None):
         """Returns an :class:`AsyncIterator` that enables receiving the guild's audit logs.
 

--- a/discord/iterators.py
+++ b/discord/iterators.py
@@ -3,8 +3,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) 2015-present Rapptz
-Copyright (c) 2021-present mccoderpy
+Copyright (c) 2015-2021 Rapptz & (c) 2021-present mccoderpy
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/discord/message.py
+++ b/discord/message.py
@@ -1404,29 +1404,6 @@ class Message(Hashable):
         """
         await self._state.http.clear_reactions(self.channel.id, self.id)
 
-    @utils.deprecated()
-    async def ack(self):
-        """|coro|
-
-        Marks this message as read.
-
-        The user must not be a bot user.
-
-        .. deprecated:: 1.7
-
-        Raises
-        -------
-        HTTPException
-            Acking failed.
-        ClientException
-            You must not be a bot user.
-        """
-
-        state = self._state
-        if state.is_bot:
-            raise ClientException('Must not be a bot account to ack messages.')
-        return await state.http.ack_message(self.channel.id, self.id)
-
     async def reply(self, content=None, **kwargs):
         """|coro|
 

--- a/discord/template.py
+++ b/discord/template.py
@@ -44,10 +44,6 @@ class _PartialTemplateState:
         self.http = _FriendlyHttpAttributeErrorHelper()
 
     @property
-    def is_bot(self):
-        return self.__state.is_bot
-
-    @property
     def shard_count(self):
         return self.__state.shard_count
 


### PR DESCRIPTION
## Fixed ratelimit management and channel.purge()

# ❗It is strongly recommended to upgrade to this version to avoid possible problems with the raitlimit.❗

- Fixed Ratelimit management what was outdated since Sep 2020. Now it really waits until the raitlimit has gone. Before it instantly started another try to send the request
- Removed any methodes that used  the `is_bot` attribute of client._connection (discord.ConnectionState) o.ä.
- The above problem was also the course for getting ratelimited when using channel.purge